### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ $(window).ready(function() {
 					</li>
 					<li> Extended linearizations for setpoint control of nonlinear systems. 
 				<a href="files/talks/16_heiland-expstab-sdre.pdf">[Talk]</a>
-				<a href="https://dx.doi.org/10.1002/rnc.3949">[Paper]</a>
+				<a href="https://doi.org/10.1002/rnc.3949">[Paper]</a>
 					</li>
 					<li> Low-dimensional controllers for stabilization of flows. 
 					   	<a href="files/talks/15_lqgbt_flow.pdf">[Talk]</a>

--- a/publications.html
+++ b/publications.html
@@ -118,7 +118,7 @@ $(function ()
 			<section id="Refereed Publications">
 				<h3>Refereed Publications</h3>
 				<p> Benner, P. and Heiland, J. (2018).
-				<a href="https://dx.doi.org/10.1002/rnc.3949">Exponential Stability and Stabilization of Extended Linearizations via Continuous Updates of Riccati Based Feedback</a>.
+				<a href="https://doi.org/10.1002/rnc.3949">Exponential Stability and Stabilization of Extended Linearizations via Continuous Updates of Riccati Based Feedback</a>.
 				<i>International Journal of Robust and Nonlinear Control</i>, Wiley, Vol. 28(4), pp. 1218-1232.<br>
 				<a class="smallbtn" href="mailto:heilandmpi-magdeburg.mpg.de?subject=I%20can%20haz%20a%20copy%20of%20[BenH17-extlinstab]">Preprint</a>
 				<a class="smallbtn" data-toggle="popover" data-placement="right" data-content="@Article{BenH18, <br> Title = {Exponential Stability and Stabilization of {E}xtended {L}inearizations via Continuous Updates of {R}iccati Based Feedback}, <br> Author = {{Benner}, P. and {Heiland}, J.}, <br> Journal =	{Internat. J. Robust and Nonlinear Cont.}, <br> Year =	2018, <br> Volume = {28}, <br> Issue = {4}, <br> Pages = {1218--1232}<br>}"
@@ -138,7 +138,7 @@ $(function ()
 				<p> Benner, P. and Heiland, J. (2017).
 				<a href="https://doi.org/10.1109/CDC.2017.8263813">Nonlinear feedback stabilization of incompressible flows via updated Riccati-based gains</a>.
 				<i>56th Annual Conference on Decision and Control (CDC)</i>, IEEE, pp.  1163-1168.<br>
-				<a href="https://dx.doi.org/10.1109/CDC.2017.8263813"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
+				<a href="https://doi.org/10.1109/CDC.2017.8263813"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
 				<a class="smallbtn" data-toggle="popover" data-placement="right" data-content="@InProceedings{BenH17b, <br> Title = {Nonlinear feedback stabilization of incompressible flows via updated {R}iccati-based gains}, <br> Author = {Benner, P. and Heiland, J.}, <br> Booktitle = {2017 IEEE 56th Annual Conference on Decision and Control (CDC)}, <br> Year = 2017,<br> Month = dec, <br> Pages = {1163--1168}, <br> Doi = {10.1109/CDC.2017.8263813} <br>}"
 					 	data-html="true">
 					 	Bibtex
@@ -148,7 +148,7 @@ $(function ()
 				<p> Benner, P. and Heiland, J. (2017).
 				<a href="http://www.sciencedirect.com/science/journal/24058963/49?sdc=1">Convergence of Approximations to Riccati-based Boundary-feedback Stabilization of Laminar Flows</a>.
 				<i>IFAC-PapersOnLine</i>, IFAC, Vol. 50, pp. 12296-12300.<br>
-				<a href="http://dx.doi.org/10.1016/j.ifacol.2017.08.2476"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
+				<a href="https://doi.org/10.1016/j.ifacol.2017.08.2476"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
 				<a class="smallbtn" data-toggle="popover" data-placement="right" data-content=" @Article{BenH17, <br> Title = {Convergence of Approximations to {R}iccati-based Boundary-feedback Stabilization of Laminar Flows},<br> Author = {Peter Benner and Jan Heiland},<br> Journal = {IFAC-PapersOnLine},<br> Year = {2017},<br> pages = {12296--12300},<br> Volume = {50}, <br> Doi = {10.1016/j.ifacol.2017.08.2476}, <br> Note = {20th IFAC World Congress}<br>}"
 					 	data-html="true">
 					 	Bibtex
@@ -157,7 +157,7 @@ $(function ()
 
 				</p>
 				<p> Ahmad, M. I., Benner, P., Goyal P., and Heiland, J. (2017).
-				<a href="http://dx.doi.org/10.1002/zamm.201500262">Moment-Matching Based Model Reduction for Navier--Stokes Type Quadratic-Bilinear Descriptor Systems</a>.
+				<a href="https://doi.org/10.1002/zamm.201500262">Moment-Matching Based Model Reduction for Navier--Stokes Type Quadratic-Bilinear Descriptor Systems</a>.
 				<i>ZAMM - Journal of Applied Mathematics and Mechanics / Zeitschrift für Angewandte Mathematik und Mechanik</i> Online first.<br>
 				<a class="smallbtn"
 			 			data-toggle="popover"
@@ -169,61 +169,61 @@ $(function ()
 				</a> 
 				</p>
 				<p> Altmann, R. and Heiland, J. (2017).
-				<a href="http://dx.doi.org/10.1007/s11044-016-9558-z">Simulation of multibody systems with servo constraints through optimal control</a>.
+				<a href="https://doi.org/10.1007/s11044-016-9558-z">Simulation of multibody systems with servo constraints through optimal control</a>.
 				<i>Multibody System Dynamics</i>, Springer, Vol. 40(1), pp. 75-98.<br>
-				<a href="http://dx.doi.org/10.1007/s11044-016-9558-z"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
+				<a href="https://doi.org/10.1007/s11044-016-9558-z"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
 				<a id="popbib8" class="smallbtn"  data-content="
-				@Article{AltH16,<br> author={Altmann, R. and Heiland, J.},<br> title={Simulation of multibody systems with servo constraints through optimal control},<br> journal=[Multibody System Dynamics},<br> volume={40},<br> issue={1},<br> year={2017},<br> pages={75--98},<br> doi={10.1007/s11044-016-9558-z},<br> url={http://dx.doi.org/10.1007/s11044-016-9558-z}<br> }
+				@Article{AltH16,<br> author={Altmann, R. and Heiland, J.},<br> title={Simulation of multibody systems with servo constraints through optimal control},<br> journal=[Multibody System Dynamics},<br> volume={40},<br> issue={1},<br> year={2017},<br> pages={75--98},<br> doi={10.1007/s11044-016-9558-z},<br> url={https://doi.org/10.1007/s11044-016-9558-z}<br> }
 					" rel="popover" >bibtex</a>
 				</p>
 				<p> Benner, P. and Heiland, J. (2016).
-				<a href="http://dx.doi.org/10.1016/j.ifacol.2016.07.414">Robust Stabilization of Laminar Flows in Varying Flow Regimes</a>.
+				<a href="https://doi.org/10.1016/j.ifacol.2016.07.414">Robust Stabilization of Laminar Flows in Varying Flow Regimes</a>.
 				<i>IFAC-PapersOnLine</i>, IFAC, Vol. 49(8), pp. 31-36.<br>
-				<a href="http://dx.doi.org/10.1016/j.ifacol.2016.07.414"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
+				<a href="https://doi.org/10.1016/j.ifacol.2016.07.414"><img  src="img/OAlogo.png" class="img-polaroid maxw-50" alt="open access logo"></a>
 				<a id="popbib7" class="smallbtn"  data-content="
 				@article{BenH16,<br> title = {Robust Stabilization of Laminar Flows in Varying Flow Regimes},<br> author = {P. Benner and J. Heiland},<br> journal = {IFAC-PapersOnLine },<br> volume = {49},<br> number = {8},<br> pages = {31 -- 36},<br> year = {2016},<br> note = {2nd \{IFAC\} Workshop on Control of Systems Governed by Partial Differential Equations \{CPDE\} 2016, Bertinoro, Italy, 13-15 June 2016 },<br> issn = {2405-8963},<br> doi = {10.1016/j.ifacol.2016.07.414}<br> }
 					" rel="popover" >bibtex</a>
 				</p>
 
 				<p> Heiland, J. (2016).
-				<a href="http://dx.doi.org/10.1137/151004963">A Differential-Algebraic Riccati Equation for Applications in Flow Control</a>.
+				<a href="https://doi.org/10.1137/151004963">A Differential-Algebraic Riccati Equation for Applications in Flow Control</a>.
 				<i>SIAM Journal on Control and Optimization</i>, SIAM, Vol. 54(2), pp. 718-739.<br>
 				<a class="smallbtn" href="mailto:heilandmpi-magdeburg.mpg.de?subject=I%20can%20haz%20a%20copy%20of%20[Hei16]">Preprint</a>
 				<a id="popbib6" class="smallbtn"  data-content="
-				@Article{Hei16,<br> author =  {Jan Heiland},<br> title =   {A Differential-Algebraic {R}iccati Equation for Applications in Flow Control},<br> journal = {SIAM Journal on Control and Optimization},<br> year =    {2016},<br> volume =  {54},<br> number =  {2},<br> pages =   {718-739},<br> doi =     {10.1137/151004963},<br> url = {http://dx.doi.org/10.1137/151004963}<br>}
+				@Article{Hei16,<br> author =  {Jan Heiland},<br> title =   {A Differential-Algebraic {R}iccati Equation for Applications in Flow Control},<br> journal = {SIAM Journal on Control and Optimization},<br> year =    {2016},<br> volume =  {54},<br> number =  {2},<br> pages =   {718-739},<br> doi =     {10.1137/151004963},<br> url = {https://doi.org/10.1137/151004963}<br>}
 					" rel="popover" >bibtex</a></p>
 				<p> Baumann, M., Heiland, J., and Schmidt, M. (2015).
-				<a href="http://dx.doi.org/10.1007/978-3-319-15260-8_21">Discrete Input/Output Maps and their Relation to Proper Orthogonal Decomposition</a>.
+				<a href="https://doi.org/10.1007/978-3-319-15260-8_21">Discrete Input/Output Maps and their Relation to Proper Orthogonal Decomposition</a>.
 				<i>Numerical Algebra, Matrix Theory, Differential-Algebraic Equations and Control Theory. Festschrift in Honor of Volker Mehrmann.</i> Springer, pp. 585-608.<br>
 				<a class="smallbtn" href="mailto:heilandmpi-magdeburg.mpg.de?subject=I%20can%20haz%20a%20copy%20of%20[BauHS15]">Preprint</a>
 				<a id="popbib5" class="smallbtn"  data-content="
 					@InCollection{BauHS15, <br>Title = {Discrete Input/Output Maps and their Relation to Proper Orthogonal Decomposition}, <br>Author = {Baumann, Manuel and Heiland, Jan and Schmidt, Michael}, <br> Booktitle = {Numerical Algebra, Matrix Theory, Differential-Algebraic Equations and Control Theory},<br> Publisher = {Springer International Publishing},<br> Year = {2015},<br> Editor = {Benner, Peter and Bollhöfer,<br> Matthias and Kressner, Daniel and Mehl, Christian and Stykel, Tatjana}, <br> Pages = {585-608},<br> Doi = {10.1007/978-3-319-15260-8_21}<br>} 
 					" rel="popover" >bibtex</a></p>
 				<p> Altmann, R. and Heiland, J. (2015).
-				<a href="http://dx.doi.org/10.1051/m2an/2015029">Finite Element Decomposition and Minimal Extension for Flow Equations</a>.
+				<a href="https://doi.org/10.1051/m2an/2015029">Finite Element Decomposition and Minimal Extension for Flow Equations</a>.
 				<i>M2AN - Mathematical Modelling and Numerical Analysis</i>, ESAIM, Vol. 49(5), pp. 1489-1509.<br>
 				<a class="smallbtn" href="http://www3.math.tu-berlin.de/preprints/files/Preprint-11-2013.pdf">Preprint</a>
 				<a class="smallbtn"
 			 			data-toggle="popover"
 			 			data-placement="top"
 			 data-content="Copyright held by: ESAIM: Mathematical Modelling and Numerical Analysis <br>
-			 Link to publisher: <a href='http://dx.doi.org/10.1051/m2an/2015029'> DOI:10.1051/m2an/2015029 </a><br>
+			 Link to publisher: <a href='https://doi.org/10.1051/m2an/2015029'> DOI:10.1051/m2an/2015029 </a><br>
 			Publisher's version: <a href='files/postprints/AltH15_M2AN_MinExtensionFlows-1.pdf'>[pdf]</a>"
 						data-html="true">
 						Postprint
 				</a>
 				<a id="popbib4" class="smallbtn"  data-content="
-					@article{AltH15,<br> Author = {{Robert Altmann} and {Jan Heiland}},<br> Title = {Finite Element Decomposition and Minimal Extension for Flow Equations},<br> Journal = {ESAIM: M2AN},<br> Year = 2015,<br> Pages = {1489 - 1509},<br> Volume = {49},<br> Number = {5},<br> DOI = {10.1051/m2an/2015029},<br> url= {http://dx.doi.org/10.1051/m2an/2015029}}
+					@article{AltH15,<br> Author = {{Robert Altmann} and {Jan Heiland}},<br> Title = {Finite Element Decomposition and Minimal Extension for Flow Equations},<br> Journal = {ESAIM: M2AN},<br> Year = 2015,<br> Pages = {1489 - 1509},<br> Volume = {49},<br> Number = {5},<br> DOI = {10.1051/m2an/2015029},<br> url= {https://doi.org/10.1051/m2an/2015029}}
 					" rel="popover" >bibtex</a></p>
 				<p> Benner, P. and Heiland, J. (2015).
 				<a href="https://doi.org/10.1007/978-3-319-11967-0_22">LQG-Balanced Truncation Low-Order Controller for Stabilization of Laminar Flows</a>.
 				<i>Active Flow and Combustion Control 2014</i>, Springer, pp. 365-379. <br>
 				<a class="smallbtn" href="http://www2.mpi-magdeburg.mpg.de/preprints/2014/04/">Preprint</a>
 				<a id="popbib3" class="smallbtn"  data-content="
- @InCollection{BenH15, <br> Title = {LQG-Balanced Truncation Low-Order Controller for Stabilization of Laminar Flows}, <br> Author = {Benner, Peter and Heiland, Jan}, <br> Booktitle = {Active Flow and Combustion Control 2014}, <br> Publisher = {Springer International Publishing}, <br> Year = {2015}, <br> Editor = {King, Rudibert}, <br> Pages = {365-379}, <br> Series = {Notes on Numerical Fluid Mechanics and Multidisciplinary Design}, <br> Volume = {127}, <br> <br> Doi = {10.1007/978-3-319-11967-0_22}, <br> ISBN = {978-3-319-11966-3}, <br> Keywords = {Navier-Stokes equation; model order reduction; stabilization; output feedback}, <br> Language = {English}, <br> Url = {http://dx.doi.org/10.1007/978-3-319-11967-0_22} <br>}
+ @InCollection{BenH15, <br> Title = {LQG-Balanced Truncation Low-Order Controller for Stabilization of Laminar Flows}, <br> Author = {Benner, Peter and Heiland, Jan}, <br> Booktitle = {Active Flow and Combustion Control 2014}, <br> Publisher = {Springer International Publishing}, <br> Year = {2015}, <br> Editor = {King, Rudibert}, <br> Pages = {365-379}, <br> Series = {Notes on Numerical Fluid Mechanics and Multidisciplinary Design}, <br> Volume = {127}, <br> <br> Doi = {10.1007/978-3-319-11967-0_22}, <br> ISBN = {978-3-319-11966-3}, <br> Keywords = {Navier-Stokes equation; model order reduction; stabilization; output feedback}, <br> Language = {English}, <br> Url = {https://doi.org/10.1007/978-3-319-11967-0_22} <br>}
 					" rel="popover" >bibtex</a></p>
 				<p> Heiland, J. and Mehrmann, V. (2012).
-				<a href="http://dx.doi.org/10.1002/zamm.201100069">Distributed control of linearized Navier-Stokes equations via discretized input/output maps</a>.
+				<a href="https://doi.org/10.1002/zamm.201100069">Distributed control of linearized Navier-Stokes equations via discretized input/output maps</a>.
 				<i>ZAMM - Journal of Applied Mathematics and Mechanics / Zeitschrift für Angewandte Mathematik und Mechanik</i>, Wiley, Vol. 92(4), pp. 257-274. <br>
 				<a class="smallbtn" title="Preprint" href="http://www3.math.tu-berlin.de/preprints/files/HeiM11_ppt.pdf">Preprint</a>
 				<a id="popbib2" class="smallbtn"  data-content="@article{HeiM12,<br>
@@ -236,7 +236,7 @@ $(function ()
 					Volume = {92},<br>
 					Number = {4},<br>
 					Publisher = {WILEY-VCH Verlag},<br>
-					Url2 = {http://dx.doi.org/10.1002/zamm.201100069}<br>
+					Url2 = {https://doi.org/10.1002/zamm.201100069}<br>
 					}" rel="popover" >bibtex</a></p>
 				<p> Heiland, J. and Mehrmann, V. and Schmidt, M. (2010).
 				<a href="http://www.springer.com/materials/mechanics/book/978-3-642-11734-3">A New Discretization Framework for Input/Output Maps and its Application to Flow Control</a>.
@@ -257,7 +257,7 @@ $(function ()
 			<section id="openreview">
 				<h3>Open Review Articles</h3>
 				<p> Benner, P. and Heiland, J. (2015).
-				<a href="http://dx.doi.org/10.14293/S2199-1006.1.SOR-MATH.AV2JW3.v1">Time-dependent Dirichlet Conditions in Finite Element Discretizations</a>.
+				<a href="https://doi.org/10.14293/S2199-1006.1.SOR-MATH.AV2JW3.v1">Time-dependent Dirichlet Conditions in Finite Element Discretizations</a>.
 				<i>ScienceOpen Research</i>.<br>
 				<span class='altmetric-embed' data-badge-popover='bottom' data-doi="10.14293/S2199-1006.1.SOR-MATH.AV2JW3.v1"></span>
 				</p>
@@ -272,7 +272,7 @@ $(function ()
 
 			<section id="proceedings">
 				<h3>Proceedings and Posters</h3>
-				<p> Baran, B. and Heiland, J. (2016) <a href="http://dx.doi.org/10.1002/pamm.201610378">Adjoint-Based Optimal Boundary Control of a Stefan Problem System Fully Coupled with Navier-Stokes Equations</a>.
+				<p> Baran, B. and Heiland, J. (2016) <a href="https://doi.org/10.1002/pamm.201610378">Adjoint-Based Optimal Boundary Control of a Stefan Problem System Fully Coupled with Navier-Stokes Equations</a>.
 				<i>PAMM Proc. Appl. Math. Mech. </i>16(1) </p>
 				<p> Baumann, M., Benner, P. and Heiland, J. (2015).
 				<a href="https://www.scienceopen.com/document/vid/47383ae1-fc56-48b1-b059-b52f4a130795">A generalized POD space-time Galerkin scheme for parameter dependent dynamical systems</a>. <i> Poster at </i><a href="http://indico.sissa.it/event/4/overview">MoRePaS 2015 - Model Reduction of Parametrized Systems III</a>, Trieste, Italy.<br>
@@ -359,8 +359,8 @@ $(function ()
 				<h4>optconpy</h4>
 				Python suite for solving velocity tracking problems on finite horizones by the Riccati based ansatz described in my PhD thesis.
 					[<a href="https://github.com/highlando/optconpy">Code</a>]
-					[<a href="http://doi.org/10.5281/zenodo.192348">DOI:10.5281/zenodo.192348</a>]
-					[<a href="http://dx.doi.org/10.1137/151004963">Related Publication</a>]
+					[<a href="https://doi.org/10.5281/zenodo.192348">DOI:10.5281/zenodo.192348</a>]
+					[<a href="https://doi.org/10.1137/151004963">Related Publication</a>]
 
 				<h4>other projects</h4>
 				<ul>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!